### PR TITLE
Fix explosion going too fast

### DIFF
--- a/src/js/gameController.js
+++ b/src/js/gameController.js
@@ -143,7 +143,7 @@ var gameController = {
         this.player = game.add.sprite(this.basketX, this.basketY, "explode");
 
         // Add animation for basket explosion in the form of a sprite sheet of 15 frames
-        this.player.animations.add('explodeBomb', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], 45);
+        this.player.animations.add('explodeBomb', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], 15);
 
         // Enable physics properties for the basket.
         this.player.scale.setTo(scaleRatio/1.5, scaleRatio/1.5);

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -97,7 +97,7 @@ var playState = {
         window.setTimeout(function () {
             backgroundMusic.stop();
             game.state.start("gameOver");
-        }, 100);
+        }, 1200);
     },
 
     /**


### PR DESCRIPTION
Lowered explosion animation framerate to 15fps (so it's 1 second long) and increased the time the game waits before moving to the gameover screen so you can see the whole animation.

(feel free to request edits to the numbers I picked, I just picked stuff that looked alright to me)