### PR TITLE
Fixes to allow game to work on different size screens

### DIFF
--- a/src/js/combo.js
+++ b/src/js/combo.js
@@ -54,9 +54,9 @@ var comboState = {
             comboEgg.body.velocity.y=gameController.eggVelocity;
 
             // Check for collision between combo egg and basket.
-            if(comboEgg.y <= gameController.player.y - comboEgg.height){
+            if(comboEgg.bottom <= gameController.player.top){
                 game.physics.arcade.collide(gameController.player, comboEgg, this.collectComboEgg, null, this);
-            } else if(comboEgg.y > gameController.player.y+gameController.player.height-comboEgg.height){
+            } else if(comboEgg.bottom > gameController.player.bottom){
                 this.crackComboEgg(comboEgg);
             }
         }
@@ -80,7 +80,7 @@ var comboState = {
      */
     setupPlayer: function(){
         //Create basket player sprite and enable physics
-        gameController.createBasket(gameController.basketX, gameController.basketY);
+        gameController.createBasket();
     },
 
     /**

--- a/src/js/gameController.js
+++ b/src/js/gameController.js
@@ -30,7 +30,12 @@ var gameController = {
     verticalAnchor: 0.5,
 
     addBackground: function(){
-        game.add.sprite(0,0, "background");
+        var backgroundSprite = game.add.sprite(game.world.centerX, game.world.height, "background");
+        backgroundSprite.anchor.setTo(0.5, 1.0);
+
+        var scalingReqdToFillWidth = canvasWidth / backgroundSprite.texture.width;
+        var scalingReqdToFillHeight = canvasHeight / backgroundSprite.texture.height;
+        backgroundSprite.scale.setTo(Math.max(scalingReqdToFillHeight, scalingReqdToFillWidth));
     },
 
     /**

--- a/src/js/gameController.js
+++ b/src/js/gameController.js
@@ -13,7 +13,7 @@ var gameController = {
     bombProb: 0,
     scoreBoostProb: 0,
     frenzyProb: 0,
-    comboPro: 0,
+    comboProb: 0,
     oneUpProb: 0,
 
     currentTime: 0,
@@ -139,7 +139,7 @@ var gameController = {
     createBasket: function(){
         if (!this.hasReachedCombo){
             this.basketX = canvasWidth/2;
-            this.basketY = canvasHeight/1.2;
+            this.basketY = canvasHeight * 0.98;
             this.hasReachedCombo = true;
         }
 
@@ -151,7 +151,7 @@ var gameController = {
 
         // Enable physics properties for the basket.
         this.player.scale.setTo(scaleRatio/1.5, scaleRatio/1.5);
-        this.player.anchor.setTo(0.5,0);
+        this.player.anchor.setTo(0.5,1.0);
         game.physics.arcade.enable(this.player, Phaser.Physics.ARCADE);
         this.player.body.kinematic = true;
         this.player.inputEnabled = true;

--- a/src/js/gameOver.js
+++ b/src/js/gameOver.js
@@ -4,7 +4,7 @@
 
 var gameOverState = {
     create: function () {
-        game.add.sprite(0,0, "background");
+        gameController.addBackground();
         var xPos = canvasWidth/2;
         var yPos = 0.3*canvasHeight;
 

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -84,7 +84,7 @@ var playState = {
             egg.body.velocity.y= gameController.eggVelocity;    // set initial vertical (y) velocity
 
             // This checks for collisions between the egg and basket, and otherwise cracks the egg if it has fallen past the basket
-            if(egg.bottom <= gameController.player.y){
+            if(egg.bottom <= gameController.player.top){
                 game.physics.arcade.collide(gameController.player, egg, this.collectEgg, null, this);
             } else if(egg.bottom > gameController.player.bottom){
                 this.crackEggs(egg);

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -84,9 +84,9 @@ var playState = {
             egg.body.velocity.y= gameController.eggVelocity;    // set initial vertical (y) velocity
 
             // This checks for collisions between the egg and basket, and otherwise cracks the egg if it has fallen past the basket
-            if(egg.y <= gameController.player.y - egg.height){
+            if(egg.bottom <= gameController.player.y){
                 game.physics.arcade.collide(gameController.player, egg, this.collectEgg, null, this);
-            } else if(egg.y > gameController.player.y+gameController.player.height-egg.height){
+            } else if(egg.bottom > gameController.player.bottom){
                 this.crackEggs(egg);
             }
 
@@ -129,14 +129,16 @@ var playState = {
     },
 
     dropEgg: function(){
-        let eggOffset = 50;
-        var eggX = Math.random() * (canvasWidth-eggOffset);     // selects a random x coordinate on the screen
+        let eggMinDistanceFromEdge = canvasWidth * 0.1;
+        let eggXRangeSize = (canvasWidth - (eggMinDistanceFromEdge * 2));
+        var eggX = (Math.random() * eggXRangeSize) + eggMinDistanceFromEdge;
         var eggY = -0.05 * canvasHeight;
         var eggType = this.getEggType();                        // determines the correct egg to drop
         var egg = game.add.sprite(eggX, eggY, eggType);
 
         // Sets the scale ratio and adds physics properties to the egg
         egg.scale.setTo(scaleRatio, scaleRatio);
+        egg.anchor.setTo(0.5);
         game.physics.enable(egg, Phaser.Physics.ARCADE);
         this.eggGravity = gameController.calculateEggGravity(gameController.currentTime);
         egg.body.gravity.y = this.eggGravity;


### PR DESCRIPTION
Haven't fixed all of the scaling issues but I got all of the major ones:
 * Background image now always covers entire screen
 * Frenzy eggs are now always fully onscreen
 * Eggs will no longer spawn partly offscreen
 * Basket height is more consistent

The major thing left to do is go over the sizing of objects & text - we'll need to do some device testing for that and also figure out *how* we want to scale things for different devices. Figured it'd be better to merge what I have now instead of letting the branches get more and more separated.