### PR TITLE
Explosion after losing last life and game over state now fixed.

### DIFF
--- a/src/js/play.js
+++ b/src/js/play.js
@@ -99,11 +99,6 @@ var playState = {
         }
     },
 
-    changeToGameOverState: function () {
-        backgroundMusic.stop();
-        game.state.start("gameOver");
-    },
-
     /**
      * This cracks the egg and plays the according animation and sound depending on type of egg
      * @param egg
@@ -256,12 +251,14 @@ var playState = {
 
             //Resume game after new basket is generated.
             game.time.gameResumed();
-        }, 1200);
 
-        if(gameController.lives === 0){
-            gameController.checkHighScore();
-            this.changeToGameOverState();
-        }
+            if(gameController.lives === 0){
+                gameController.checkHighScore();
+                backgroundMusic.stop();
+                game.state.start("gameOver");
+            }
+
+        }, 1200);
 
         if(gameController.lives<gameController.maxLives){
             this.calculateEggProbability(gameController.currentTime);


### PR DESCRIPTION
Turns out the explosion after losing last life wasn't actually working. I probably missed it because of browser caching. 

I've fixed it in this branch. Please review it. It's sort of a hacky fix. The window.setTimeout function does not recognize methods in the play.js file because of scope issues. Due to that, I had to remove the switchToGameOverState function and execute its contents in the window.setTimeout function. 

Please review it and let me know if there are any issues.