### PR TITLE
Instead of using Phaser dragging, set bucket X to thumb X...

### DIFF
--- a/src/js/boot.js
+++ b/src/js/boot.js
@@ -4,6 +4,12 @@
 var bootState = {
     preload: function() {
         game.time.advancedTiming = true;
+
+        //For some reason phaser's default behavior is to reset all input whenever it 
+        //switches to a new state, which means if the player holds their thumb down
+        //in between states phaser will pretend like they stopped when the state switched.
+        //Setting resetLocked to true disables this behavior.
+        game.input.resetLocked = true;
     },
 
     //The create function is a standard Phaser function, and is automatically called

--- a/src/js/combo.js
+++ b/src/js/combo.js
@@ -50,6 +50,7 @@ var comboState = {
      */
     update: function(){
         gameController.updateRainbowScoreColor();
+        gameController.updateBasketPosition();
         for(var comboEgg of this.comboEggs.children){
             // For each egg in the combo state. Set the initial velocity of the eggs
             comboEgg.body.velocity.y=gameController.eggVelocity;

--- a/src/js/gameController.js
+++ b/src/js/gameController.js
@@ -51,6 +51,7 @@ var gameController = {
     frenzyPoints: 5,
     comboPoints: 100,
     eggVelocity: 20,
+    bucketMovementEnabled: true,
 
     // If an object is placed at a point (x,y), the anchor will set the center of the object to be (x,y)
     horizontalAnchor: 0.5,
@@ -198,16 +199,21 @@ var gameController = {
         this.player.anchor.setTo(0.5,1.0);
         game.physics.arcade.enable(this.player, Phaser.Physics.ARCADE);
         this.player.body.kinematic = true;
-        this.player.inputEnabled = true;
-        this.player.input.enableDrag(false, true, true);
-        this.player.input.allowVerticalDrag = false;
         this.player.collideWorldBounds = true;
-        let bounds = new Phaser.Rectangle(0,0, canvasWidth, canvasHeight);
-        this.player.input.boundsRect = bounds;
         this.player.body.immovable = true;
         this.player.allowGravity = false;
+        this.bucketMovementEnabled = true;
 
         this.player.body.setSize(127, 30, 12, 40);
+    },
+
+    updateBasketPosition: function() {
+        if(this.bucketMovementEnabled && game.input.activePointer.isDown) {
+            let mouseX = game.input.activePointer.x;
+            if(Math.abs(this.player.position.x - mouseX) < canvasWidth / 2) {
+                this.player.position.x = mouseX;
+            }
+        }
     },
 
     createPauseLabel: function(){

--- a/src/js/gameController.js
+++ b/src/js/gameController.js
@@ -211,7 +211,10 @@ var gameController = {
         if(this.bucketMovementEnabled && game.input.activePointer.isDown) {
             let mouseX = game.input.activePointer.x;
             if(Math.abs(this.player.position.x - mouseX) < canvasWidth / 2) {
-                this.player.position.x = mouseX;
+                let maxX = canvasWidth - this.player.width / 2;
+                let minX =  this.player.width / 2;
+                let newX = Math.max(minX, Math.min(mouseX, maxX))
+                this.player.position.x = newX;
             }
         }
     },

--- a/src/js/play.js
+++ b/src/js/play.js
@@ -85,6 +85,7 @@ var playState = {
      */
     update: function(){
         gameController.updateRainbowScoreColor();
+        gameController.updateBasketPosition();
         for(var egg of this.eggs.children){
             egg.body.velocity.y= gameController.eggVelocity;    // set initial vertical (y) velocity
 
@@ -268,7 +269,7 @@ var playState = {
         //Stopping eggs from falling by pausing all the time events loop to begin explosion animation
         game.time.gamePaused();
         gameController.player.animations.play('explodeBomb');
-        gameController.player.inputEnabled = false;
+        gameController.bucketMovementEnabled = false;
         gameController.player.body.enable = false;
 
         //Timeout for animation to play before the basket is generated again


### PR DESCRIPTION
...but only if the player's thumb is close enough to the bucket along the X-axis. This way they can't just tap anywhere on the screen to teleport the bucket to their thumb. RIght now their thumb has to be within half of the screen size away - I wanted the distance to be big enough that the user can still drag really fast and not lose their drag. However since it doesn't cover the whole screen it makes tapping a much harder strategy.

I recommend yall download this branch and test it yourself, we may want to adjust the bucket's tap radius (or switch back to a dragging system)